### PR TITLE
Added ability to sync read state of book if available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -458,6 +458,21 @@ fn load_and_process_opds() -> Result<(), Error> {
 
                 // Get the current time.
                 let updated_at = Utc::now();
+
+                let mut read_state = json!({
+                    "opened": updated_at.with_timezone(&Local)
+                                       .format("%Y-%m-%d %H:%M:%S")
+                                       .to_string(),
+                    "currentPage": 0,
+                    "PagesCount": 1,
+                    "finished": false,
+                    "dithered": "false"
+                });
+
+                if instance.url.contains("/readbooks") {
+                    *read_state.pointer_mut("/finished").unwrap() = true.into();
+                }
+
                 let info = json!({
                     "title": result.entry.title,
                     "author": author,
@@ -467,6 +482,7 @@ fn load_and_process_opds() -> Result<(), Error> {
                                        .format("%Y-%m-%d %H:%M:%S")
                                        .to_string(),
                     "file": file_info,
+                    "reader": read_state
                 });
 
                 plato::add_document(info);


### PR DESCRIPTION
Wanted the ability to sync already finished books to plato but mark them as read so they won't show up in my default view.

calibre-web has the opds routes `/opds/readbooks` and `/opds/unreadbooks` meaning you can set two servers one for unreadbooks and one for readbooks so you can set the read status as required.

The requisite support in plato was added in https://github.com/baskerville/plato/commit/d3dcf35e06d8970e442282941a47138095f4879f