### PR TITLE
Re-download updated entries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use anyhow::{format_err, Context, Error};
-use chrono::{Datelike, Local, Utc};
+use chrono::{DateTime, Datelike, Local, Utc};
 use reqwest::{
     blocking::{Client, Response},
     IntoUrl,
@@ -398,8 +398,18 @@ fn load_and_process_opds() -> Result<(), Error> {
 
                 doc_path = doc_path.join(file_name);
 
-                if doc_path.exists() {
-                    return None;
+                // default to Unix Epoch; if there is no updated field in the entry then should never update
+                let entry_last_updated = entry.updated.unwrap_or(DateTime::UNIX_EPOCH);
+                let last_modified = fs::metadata(&doc_path).map(|metadata| {
+                    metadata
+                        .modified()
+                        .map(DateTime::<Utc>::from)
+                        .unwrap_or(DateTime::UNIX_EPOCH)
+                });
+                match last_modified {
+                    Ok(last_modified) if entry_last_updated > last_modified => {}
+                    Ok(_) => return None, // file on disk updated more recently so we'll skip
+                    Err(_) => {}          // an error likely implies the file does not exist
                 }
 
                 Some(EntryResult {
@@ -420,10 +430,6 @@ fn load_and_process_opds() -> Result<(), Error> {
             }
 
             let doc_path = result.save_path;
-            if doc_path.exists() {
-                continue;
-            }
-
             let mut file = File::create(&doc_path)?;
             let mut url = Url::parse(&instance.url)?;
             url.set_path(&result.link.href.ok_or(format_err!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,10 @@ use std::{
 
 use anyhow::{format_err, Context, Error};
 use chrono::{Datelike, Local, Utc};
-use reqwest::blocking::Client;
+use reqwest::{
+    blocking::{Client, Response},
+    IntoUrl,
+};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use url::Url;
@@ -223,6 +226,18 @@ fn print_sync_notification(server_name: &String, results: &[EntryResult]) {
         });
 }
 
+fn fetch(
+    client: &Client,
+    url: impl IntoUrl,
+    credentials: &Option<(String, Option<String>)>,
+) -> reqwest::Result<Response> {
+    let mut builder = client.get(url);
+    if let Some((username, password)) = credentials {
+        builder = builder.basic_auth(username, password.as_ref())
+    }
+    builder.send()
+}
+
 fn load_and_process_opds() -> Result<(), Error> {
     let mut args = env::args().skip(1);
     let library_path = PathBuf::from(
@@ -279,13 +294,9 @@ fn load_and_process_opds() -> Result<(), Error> {
         }
 
         let instance_path = save_path.join(name);
-        let username = &instance.username.clone().unwrap_or("admin".to_string());
-        let password = instance.password.as_ref();
+        let credentials = (|| Some((instance.username.clone()?, instance.password.clone())))();
 
-        let response = client
-            .get(&instance.url)
-            .basic_auth(username, password)
-            .send()?;
+        let response = fetch(&client, &instance.url, &credentials)?;
 
         let xml = response.text()?;
         let mut feed = quick_xml::de::from_str::<Feed>(&xml)?;
@@ -310,7 +321,7 @@ fn load_and_process_opds() -> Result<(), Error> {
                 false => Url::parse(&url_string).expect("Can't parse paginated url"),
             };
 
-            let response = client.get(url).basic_auth(username, password).send()?;
+            let response = fetch(&client, url, &credentials)?;
 
             let xml = response.text()?;
             let next_feed = quick_xml::de::from_str::<Feed>(&xml)?;
@@ -420,10 +431,7 @@ fn load_and_process_opds() -> Result<(), Error> {
                 result.entry.title
             ))?);
 
-            let response = client
-                .get(url)
-                .basic_auth(username, password)
-                .send()
+            let response = fetch(&client, url, &credentials)
                 .and_then(|mut response| response.copy_to(&mut file));
 
             if let Err(err) = response {

--- a/src/opds.rs
+++ b/src/opds.rs
@@ -43,6 +43,8 @@ pub struct Entry {
     pub publishers: Option<Vec<Publisher>>,
     /// The date the book was published.
     pub published: Option<DateTime<Utc>>,
+    /// The date the book was last updated.
+    pub updated: Option<DateTime<Utc>>,
     /// The links to the book's resources. Usually contains a link to the book files.
     #[serde(rename = "link")]
     pub links: Option<Vec<Link>>,


### PR DESCRIPTION
The current behavior is to not repeat a download if the file already exists on disk. This commit adds an additional check -- if the `updated` field of an OPDS entry is more recent than the last modified time of the file then it will re-download the file and emit an
addDocument event.

This MR is a draft because A) it was written on top of https://github.com/videah/plato-opds/pull/6 and B) I haven't tested it on plato yet. It does correctly update files but I want to confirm the semantics behind sending an addDocument event for a file that already exists. Looks like it's path-indexed and will update things but that's just my understanding from reading through it. 

